### PR TITLE
Remove an ignore on a directory that doesn't even exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ Puppetfile.lock*
 # Vagrant
 vagrant/.vagrant
 vagrant/instance/
-vagrant/master/
 vagrant/*.vdi
 
 # Environments directory


### PR DESCRIPTION
It was something from a previous implementation that was not even in use
anymore.
